### PR TITLE
Implement std::error::Error and fmt::Display for Error types

### DIFF
--- a/mqtt3/src/error.rs
+++ b/mqtt3/src/error.rs
@@ -1,5 +1,7 @@
 use std::result;
 use std::io;
+use std::fmt;
+use std::error;
 use std::string::FromUtf8Error;
 use byteorder;
 
@@ -41,6 +43,41 @@ impl From<byteorder::Error> for Error {
         match err {
             byteorder::Error::UnexpectedEOF => Error::UnexpectedEof,
             byteorder::Error::Io(err) => Error::Io(err)
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::write(f, format_args!("{:?}", *self))
+    }
+}
+
+impl error::Error for Error {
+    fn description<'a>(&'a self) -> &'a str {
+        match *self {
+            Error::IncorrectPacketFormat => "Incorrect Packet Format",
+            Error::InvalidTopicPath => "Invalid Topic Path",
+            Error::UnsupportedProtocolName => "Unsupported Protocol Name",
+            Error::UnsupportedProtocolVersion => "Unsupported Protocol Version",
+            Error::UnsupportedQualityOfService => "Unsupported Quality Of Service",
+            Error::UnsupportedPacketType => "Unsupported Packet Type",
+            Error::UnsupportedConnectReturnCode => "Unsupported Connect Return Code",
+            Error::PayloadSizeIncorrect => "Payload Size Incorrect",
+            Error::PayloadTooLong => "Payload Too Long",
+            Error::PayloadRequired => "Payload Required",
+            Error::TopicNameMustNotContainNonUtf8 => "Topic Name Must Not Contain Non Utf 8",
+            Error::TopicNameMustNotContainWildcard => "Topic Name Must Not Contain Wildcard",
+            Error::MalformedRemainingLength => "Malformed Remaining Length",
+            Error::UnexpectedEof => "Unexpected Eof",
+            Error::Io(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Io(ref err) => Some(err),
+            _ => None,
         }
     }
 }

--- a/mqttc/src/store.rs
+++ b/mqttc/src/store.rs
@@ -1,4 +1,6 @@
 use std::result;
+use std::error;
+use std::fmt;
 use mqtt3::{Message, PacketIdentifier};
 
 pub type Result<T> = result::Result<T, Error>;
@@ -14,4 +16,28 @@ pub trait Store {
 pub enum Error {
     NotFound(PacketIdentifier),
     Unavailable(PacketIdentifier)
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::NotFound(PacketIdentifier(packet_identifier)) =>
+                fmt::write(f, format_args!("Packet {} not found", packet_identifier)),
+            Error::Unavailable(PacketIdentifier(packet_identifier)) =>
+                fmt::write(f, format_args!("Packet {} unavailable", packet_identifier)),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::NotFound(PacketIdentifier(_)) =>  "Packet not found",
+            Error::Unavailable(PacketIdentifier(_)) => "Packet unavailable",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
+    }
 }


### PR DESCRIPTION
This makes it easier for downstream projects to implement their own error and result types:
https://doc.rust-lang.org/book/error-handling.html#standard-library-traits-used-for-error-handling
