### PR TITLE
Adjust display QoS levels for subscribe to be 0-2 rather than 1-3.

### DIFF
--- a/src/client/command/subscribe.rs
+++ b/src/client/command/subscribe.rs
@@ -200,11 +200,11 @@ fn print_legend() {
     t.fg(term::color::BRIGHT_GREEN).unwrap();
     write!(t, "        Legend ").unwrap();
     t.fg(term::color::BRIGHT_CYAN).unwrap();
-    write!(t, "QoS 1 ").unwrap();
+    write!(t, "QoS 0 ").unwrap();
     t.fg(term::color::BRIGHT_MAGENTA).unwrap();
-    write!(t, "QoS 2 ").unwrap();
+    write!(t, "QoS 1 ").unwrap();
     t.fg(term::color::BRIGHT_BLUE).unwrap();
-    writeln!(t, "QoS 3 ").unwrap();
+    writeln!(t, "QoS 2 ").unwrap();
     t.fg(term::color::BRIGHT_GREEN).unwrap();
     //writeln!(t, "Network").unwrap();
     //t.reset().unwrap();


### PR DESCRIPTION
Adjusted the "Legend" display when subscribing to display QoS levels 0-2 rather than 1-3. 