### PR TITLE
Fix mqttc/netops compilation without openssl

### DIFF
--- a/mqttc/Cargo.toml
+++ b/mqttc/Cargo.toml
@@ -6,12 +6,16 @@ description = "Mqttc is a client for the MQTT protocol."
 repository = "https://github.com/inre/rust-mq"
 license = "MIT"
 
+[features]
+default = ["ssl"]
+ssl = ["netopt/ssl"]
+
 [dependencies]
 log = "0.3"
 rand = "0.3"
 byteorder = "0.4"
 mqtt3 = "0.1" # { path = "../mqtt3" }
-netopt = "0.1" # { path = "../netopt" }
+netopt = { version = "0.1", default-features = false } # { path = "../netopt" }
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/netopt/src/lib.rs
+++ b/netopt/src/lib.rs
@@ -16,6 +16,7 @@ pub use tcp::{
     NetworkReader
 };
 
+#[cfg(feature = "ssl")]
 pub use ssl::{
     SslContext,
     SslStream,
@@ -32,15 +33,29 @@ pub mod ssl {
     use std::net::TcpStream;
     use std::io;
     use std::error::Error;
+    use std::path::Path;
 
     pub type SslStream = MockStream;
-    pub type SslError = Error;
+    pub type SslError = Error + 'static;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Default)]
     pub struct SslContext;
 
     impl SslContext {
+        pub fn new(_: SslContext) -> Self {
+            panic!("ssl disabled");
+        }
+
+        pub fn with_cert_and_key<C, K, E>(_: C, _: K) -> Result<SslContext, E>
+        where C: AsRef<Path>, K: AsRef<Path>, E: Error + 'static {
+            panic!("ssl disabled");
+        }
+
         pub fn accept(&self, _: TcpStream) -> Result<SslStream, io::Error> {
+            panic!("ssl disabled");
+        }
+
+        pub fn connect(&self, _: TcpStream) -> Result<SslStream, io::Error> {
             panic!("ssl disabled");
         }
     }

--- a/netopt/src/mock.rs
+++ b/netopt/src/mock.rs
@@ -1,4 +1,6 @@
 use std::io::{self, Cursor, Read, Write};
+use std::net::{SocketAddr, Shutdown};
+use std::time::Duration;
 use std::sync::{Mutex, Arc};
 
 pub type MockCursor = Cursor<Vec<u8>>;
@@ -51,6 +53,32 @@ impl MockStream {
         // swap cursors
         cur_read.get_mut().extend_from_slice(vec_write.as_slice());
         cur_write.get_mut().extend_from_slice(vec_read.as_slice());
+    }
+}
+
+impl MockStream {
+    pub fn try_clone(&self) -> io::Result<MockStream> {
+        unimplemented!()
+    }
+
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        unimplemented!()
+    }
+
+    pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    pub fn get_ref(&self) -> Self {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
Hello,

It wasn't impossible to compile `mqttc` without openssl and after trying to compile it with `netopt` in `no-default-features` it appeared that `netopt` didn't compile either without openssl.
So I fixed the `netopt` crate and add the possibility to `mqttc` to compile in `no-default-features`.

I did not manage to make the `rustmq` package compilable without openssl as it has it as a direct dependency but at least we can now use `mqttc` and `netopts` are compilable now.
