### PR TITLE
WIP: Update OpenSSL dependency to support newer versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ name = "rustmq"
 path = "src/lib.rs"
 
 [dependencies]
-term = "0.2"
+term = "0.4"
 getopts = "0.2"
 openssl = { version = "0.10" }
 log = "0.3"
-env_logger = "0.3"
-"mqtt3" = "0.1" # { path = "mqtt3" }
-"netopt" = "0.1" # { path = "netopt" }
-"mqttc" = "0.1" # { path = "mqttc" }
+env_logger = "0.6"
+# "mqtt3" = "0.1" # { path = "mqtt3" }
+# "netopt" = "0.1" # { path = "netopt" }
+# "mqttc" = "0.1" # { path = "mqttc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ getopts = "0.2"
 openssl = { version = "0.10" }
 log = "0.3"
 env_logger = "0.6"
-# "mqtt3" = "0.1" # { path = "mqtt3" }
-# "netopt" = "0.1" # { path = "netopt" }
-# "mqttc" = "0.1" # { path = "mqttc" }
+"mqtt3" = "0.1" # { path = "mqtt3" }
+"netopt" = "0.1" # { path = "netopt" }
+"mqttc" = "0.1" # { path = "mqttc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 [dependencies]
 term = "0.2"
 getopts = "0.2"
-openssl = { version = "0.7", features = ["tlsv1_1", "tlsv1_2"] }
+openssl = { version = "0.10" }
 log = "0.3"
 env_logger = "0.3"
 "mqtt3" = "0.1" # { path = "mqtt3" }

--- a/examples/mqtt3_pub.rs
+++ b/examples/mqtt3_pub.rs
@@ -2,20 +2,20 @@ extern crate mqtt3;
 
 use std::env;
 use std::net::TcpStream;
-use std::io::{Read, Write, BufReader, BufWriter};
+use std::io::{Write, BufReader, BufWriter};
 use std::process::exit;
 use mqtt3::{MqttRead, MqttWrite, Packet, Connect, Publish, Protocol, QoS, PacketIdentifier};
 use std::sync::Arc;
 
 fn main() {
-    let mut args: Vec<_> = env::args().collect();
+    let args: Vec<_> = env::args().collect();
     if args.len() < 2 {
         println!("Usage: cargo run --example mqtt3_pub -- 127.0.0.1:1883");
         exit(1);
     }
     let ref address = args[1];
     println!("Establish connection to {}", address);
-    let mut stream = TcpStream::connect(address.as_str()).unwrap();
+    let stream = TcpStream::connect(address.as_str()).unwrap();
     let mut reader = BufReader::new(stream.try_clone().unwrap());
     let mut writer = BufWriter::new(stream.try_clone().unwrap());
 
@@ -30,8 +30,8 @@ fn main() {
         password: None
     }));
     println!("{:?}", connect);
-    writer.write_packet(&connect);
-    writer.flush();
+    writer.write_packet(&connect).unwrap();
+    writer.flush().unwrap();
     let packet = reader.read_packet().unwrap();
     println!("{:?}", packet);
 
@@ -45,8 +45,8 @@ fn main() {
         payload: Arc::new("Hello world".to_string().into_bytes())
     }));
     println!("{:?}", publish);
-    writer.write_packet(&publish);
-    writer.flush();
+    writer.write_packet(&publish).unwrap();
+    writer.flush().unwrap();
     let packet = reader.read_packet().unwrap();
     println!("{:?}", packet);
 }

--- a/examples/mqtt3_sub.rs
+++ b/examples/mqtt3_sub.rs
@@ -2,20 +2,19 @@ extern crate mqtt3;
 
 use std::env;
 use std::net::TcpStream;
-use std::io::{Read, Write, BufReader, BufWriter};
+use std::io::{Write, BufReader, BufWriter};
 use std::process::exit;
-use mqtt3::{MqttRead, MqttWrite, Packet, Connect, Publish, Subscribe, Protocol, QoS, PacketIdentifier};
-use std::sync::Arc;
+use mqtt3::{MqttRead, MqttWrite, Packet, Connect, Subscribe, Protocol, QoS, PacketIdentifier};
 
 fn main() {
-    let mut args: Vec<_> = env::args().collect();
+    let args: Vec<_> = env::args().collect();
     if args.len() < 2 {
         println!("Usage: cargo run --example mqtt3_sub -- 127.0.0.1:1883");
         exit(1);
     }
     let ref address = args[1];
     println!("Establish connection to {}", address);
-    let mut stream = TcpStream::connect(address.as_str()).unwrap();
+    let stream = TcpStream::connect(address.as_str()).unwrap();
     let mut reader = BufReader::new(stream.try_clone().unwrap());
     let mut writer = BufWriter::new(stream.try_clone().unwrap());
 
@@ -30,8 +29,8 @@ fn main() {
         password: None
     }));
     println!("{:?}", connect);
-    writer.write_packet(&connect);
-    writer.flush();
+    writer.write_packet(&connect).unwrap();
+    writer.flush().unwrap();
     let packet = reader.read_packet().unwrap();
     println!("{:?}", packet);
 
@@ -43,8 +42,8 @@ fn main() {
         ]
     }));
     println!("{:?}", subscribe);
-    writer.write_packet(&subscribe);
-    writer.flush();
+    writer.write_packet(&subscribe).unwrap();
+    writer.flush().unwrap();
     let packet = reader.read_packet().unwrap();
     println!("{:?}", packet);
 
@@ -59,8 +58,8 @@ fn main() {
                     if let Some(pid) = publish.pid {
                         let packet = Packet::Puback(pid);
                         println!("{:?}", packet);
-                        writer.write_packet(&packet);
-                        writer.flush();
+                        writer.write_packet(&packet).unwrap();
+                        writer.flush().unwrap();
                     }
                 }
             },

--- a/mqttc/Cargo.toml
+++ b/mqttc/Cargo.toml
@@ -11,11 +11,11 @@ default = ["ssl"]
 ssl = ["netopt/ssl"]
 
 [dependencies]
-log = "0.3"
-rand = "0.3"
-byteorder = "0.4"
-mqtt3 = "0.1" # { path = "../mqtt3" }
-netopt = { version = "0.1", default-features = false } # { path = "../netopt" }
+log = "0.4"
+rand = "0.6"
+byteorder = "0.5"
+# mqtt3 = "0.1" # { path = "../mqtt3" }
+# netopt = { version = "0.1.3", default-features = false } # { path = "../netopt" }
 
 [dev-dependencies]
-env_logger = "0.3"
+env_logger = "0.6"

--- a/mqttc/Cargo.toml
+++ b/mqttc/Cargo.toml
@@ -14,8 +14,8 @@ ssl = ["netopt/ssl"]
 log = "0.4"
 rand = "0.6"
 byteorder = "0.5"
-# mqtt3 = "0.1" # { path = "../mqtt3" }
-# netopt = { version = "0.1.3", default-features = false } # { path = "../netopt" }
+mqtt3 = "0.1" # { path = "../mqtt3" }
+netopt = { version = "0.1.3", default-features = false } # { path = "../netopt" }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/netopt/Cargo.toml
+++ b/netopt/Cargo.toml
@@ -11,5 +11,5 @@ default = ["ssl"]
 ssl = ["openssl"]
 
 [dependencies]
-openssl = { version = "0.7", optional = true, features = ["tlsv1_1", "tlsv1_2"] }
+openssl = { version = "0.10", optional = true }
 mqtt3 = "0.1" # { path = "../mqtt3" }

--- a/netopt/src/ssl.rs
+++ b/netopt/src/ssl.rs
@@ -2,11 +2,10 @@ use std::net::TcpStream;
 use std::io;
 use std::sync::Arc;
 use std::path::Path;
-use openssl::ssl::{self, SslMethod, SSL_VERIFY_NONE, SSL_VERIFY_PEER, SSL_VERIFY_FAIL_IF_NO_PEER_CERT};
-use openssl::x509::X509FileType;
+use openssl::ssl::{self, SslFiletype, SslMethod, SslVerifyMode};
 
 pub type SslStream = ssl::SslStream<TcpStream>;
-pub type SslError = ssl::error::SslError;
+pub type SslError = ssl::Error;
 
 #[derive(Debug, Clone)]
 pub struct SslContext {
@@ -16,7 +15,7 @@ pub struct SslContext {
 impl Default for SslContext {
     fn default() -> SslContext {
         SslContext {
-            inner: Arc::new(ssl::SslContext::new(SslMethod::Tlsv1_2).unwrap())
+            inner: Arc::new(ssl::SslContext::builder(SslMethod::tls()).unwrap().build())
         }
     }
 }
@@ -30,34 +29,34 @@ impl SslContext {
 
     pub fn with_cert_and_key<C, K>(cert: C, key: K) -> Result<SslContext, SslError>
     where C: AsRef<Path>, K: AsRef<Path> {
-        let mut ctx = try!(ssl::SslContext::new(SslMethod::Sslv23));
-        try!(ctx.set_cipher_list("DEFAULT"));
-        try!(ctx.set_certificate_file(cert.as_ref(), X509FileType::PEM));
-        try!(ctx.set_private_key_file(key.as_ref(), X509FileType::PEM));
-        ctx.set_verify(SSL_VERIFY_NONE, None);
-        Ok(SslContext { inner: Arc::new(ctx) })
+        let mut ctx = ssl::SslContext::builder(SslMethod::tls())?;
+        ctx.set_cipher_list("DEFAULT")?;
+        ctx.set_certificate_file(cert.as_ref(), SslFiletype::PEM)?;
+        ctx.set_private_key_file(key.as_ref(), SslFiletype::PEM)?;
+        ctx.set_verify(SslVerifyMode::NONE);
+        Ok(SslContext { inner: Arc::new(ctx.build()) })
     }
 
     pub fn with_cert_and_key_and_ca<C, K, A>(cert: C, key: K, ca: A) -> Result<SslContext, SslError>
     where C: AsRef<Path>, K: AsRef<Path>, A: AsRef<Path> {
-        let mut ctx = try!(ssl::SslContext::new(SslMethod::Sslv23));
-        try!(ctx.set_cipher_list("DEFAULT"));
-        try!(ctx.set_certificate_file(cert.as_ref(), X509FileType::PEM));
-        try!(ctx.set_private_key_file(key.as_ref(), X509FileType::PEM));
-        try!(ctx.set_CA_file(ca.as_ref()));
-        ctx.set_verify(SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, None);
-        Ok(SslContext { inner: Arc::new(ctx) })
+        let mut ctx = ssl::SslContext::builder(SslMethod::tls())?;
+        ctx.set_cipher_list("DEFAULT")?;
+        ctx.set_certificate_file(cert.as_ref(), SslFiletype::PEM)?;
+        ctx.set_private_key_file(key.as_ref(), SslFiletype::PEM)?;
+        ctx.set_ca_file(ca.as_ref())?;
+        ctx.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+        Ok(SslContext { inner: Arc::new(ctx.build()) })
     }
 
     pub fn accept(&self, stream: TcpStream) -> Result<SslStream, io::Error> {
-        match ssl::SslStream::accept(&*self.inner, stream) {
+        match ssl::Ssl::new(&*self.inner)?.accept(stream) {
             Ok(stream) => Ok(stream),
             Err(err) => Err(io::Error::new(io::ErrorKind::ConnectionAborted, err).into())
         }
     }
 
     pub fn connect(&self, stream: TcpStream) -> Result<SslStream, io::Error> {
-        match ssl::SslStream::connect(&*self.inner, stream) {
+        match ssl::Ssl::new(&*self.inner)?.connect(stream) {
             Ok(stream) => Ok(stream),
             Err(err) => Err(io::Error::new(io::ErrorKind::ConnectionAborted, err).into())
         }

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -1,7 +1,6 @@
 use std::process::exit;
 use getopts::Options;
-use openssl::ssl::{SslMethod, SslContext, SslVerifyMode};
-use openssl::x509::X509FileType;
+use openssl::ssl::{SslMethod, SslContext, SslFiletype, SslVerifyMode};
 use mqtt3::{LastWill, SubscribeTopic, QoS, Protocol};
 use super::command::{Command, SubscribeCommand, PublishCommand};
 
@@ -133,9 +132,10 @@ impl CLI {
         let cert = matches.opt_str("cert");
         let ssl_method = if matches.opt_present("tls") {
             match matches.opt_str("tls").unwrap().as_ref() {
-                "1" => Some(SslMethod::Tlsv1),
-                "1.1" => Some(SslMethod::Tlsv1_1),
-                "1.2" => Some(SslMethod::Tlsv1_2),
+                // FIXME: TLS versions are ignored here
+                "1" => Some(SslMethod::tls()),
+                "1.1" => Some(SslMethod::tls()),
+                "1.2" => Some(SslMethod::tls()),
                 _ => {
                     self.cli_error("unsupported TLS version")
                 }
@@ -150,18 +150,18 @@ impl CLI {
         };
 
         let ssl_context = ssl_method.map(|ssl| {
-            let mut context = SslContext::new(ssl).unwrap();
-            context.set_verify(verify_mode, None);
+            let mut context = SslContext::builder(ssl).unwrap();
+            context.set_verify(verify_mode);
             if let Some(ref cafile_path) = cafile {
-                context.set_CA_file(cafile_path).unwrap();
+                context.set_ca_file(cafile_path).unwrap();
             }
             if let Some(ref key_path) = key {
-                context.set_private_key_file(key_path, X509FileType::PEM).unwrap();
+                context.set_private_key_file(key_path, SslFiletype::PEM).unwrap();
             }
             if let Some(ref cert_path) = cert {
-                context.set_certificate_file(cert_path, X509FileType::PEM).unwrap();
+                context.set_certificate_file(cert_path, SslFiletype::PEM).unwrap();
             }
-            context
+            context.build()
         });
 
         PublishCommand {
@@ -311,9 +311,10 @@ impl CLI {
         let cert = matches.opt_str("cert");
         let ssl_method = if matches.opt_present("tls") {
             match matches.opt_str("tls").unwrap().as_ref() {
-                "1" => Some(SslMethod::Tlsv1),
-                "1.1" => Some(SslMethod::Tlsv1_1),
-                "1.2" => Some(SslMethod::Tlsv1_2),
+                // FIXME: TLS versions are ignored here
+                "1" => Some(SslMethod::tls()),
+                "1.1" => Some(SslMethod::tls()),
+                "1.2" => Some(SslMethod::tls()),
                 _ => {
                     self.cli_error("unsupported TLS version")
                 }
@@ -328,18 +329,18 @@ impl CLI {
         };
 
         let ssl_context = ssl_method.map(|ssl| {
-            let mut context = SslContext::new(ssl).unwrap();
-            context.set_verify(verify_mode, None);
+            let mut context = SslContext::builder(ssl).unwrap();
+            context.set_verify(verify_mode);
             if let Some(ref cafile_path) = cafile {
-                context.set_CA_file(cafile_path).unwrap();
+                context.set_ca_file(cafile_path).unwrap();
             }
             if let Some(ref key_path) = key {
-                context.set_private_key_file(key_path, X509FileType::PEM).unwrap();
+                context.set_private_key_file(key_path, SslFiletype::PEM).unwrap();
             }
             if let Some(ref cert_path) = cert {
-                context.set_certificate_file(cert_path, X509FileType::PEM).unwrap();
+                context.set_certificate_file(cert_path, SslFiletype::PEM).unwrap();
             }
-            context
+            context.build()
         });
 
         let retain = false; //TODO: !matches.opt_present("no-retain");


### PR DESCRIPTION
This PR attempts to:
- Fix: #27 
- Fix: #28 

I've attempted to upgrade the `openssl` dependency to support newer OpenSSL versions (>1.0), this is a required upgrade to build on systems having newer packages. I explicitly said _attempted_ because it isn't fully done yet. The upgrade required some refactoring, which needs some review. The current PR also left a single build error due to deprecation, for which I don't know what to do.

---

#### 1. TLS versions
The SSL/TLS method selection for TLS `1.{0..2}` now uses `SslMethod::tls()`, without an explicit TLS version. According to the [documentation](https://docs.rs/openssl/0.10.16/openssl/ssl/struct.SslMethod.html#method.tls) this is a valid replacement. Does this make the actual TLS version selection obsolete? Should we remove the match branches and just return `tls()`?

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/src/client/cli.rs#L136-L138

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/src/client/cli.rs#L315-L317

#### 2. X509 file type PEM
I replaced `X509FileType::PEM` with [`SslFiletype::PEM`](https://docs.rs/openssl/0.10.16/openssl/ssl/struct.SslFiletype.html#associatedconstant.PEM) in many places. I don't know whether this is a valid.

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/netopt/src/ssl.rs#L34-L35

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/netopt/src/ssl.rs#L44-L45

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/src/client/cli.rs#L159-L162

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/src/client/cli.rs#L338-L341

#### 3. try_clone() removed
The `try_clone()` function on `SslStream`s has been removed in newer `openssl` versions because it is broken according to [this](https://github.com/sfackler/rust-openssl/issues/325). With no replacement, this breaks the `try_clone()` function in `rust-mq`. What to do about this? Should the `Ssl` branch (line 89 below) panic/return an error? Should the function be removed entirely?

https://github.com/inre/rust-mq/blob/2e0a08b1a186a9e2945fb661179295bc3a8761c3/netopt/src/tcp.rs#L86-L92

---

The PR also includes upgrades of other dependencies that didn't require refactoring, and fixes warnings produced by examples when running `cargo test`.

To build/test/use this PR, make sure to switch to the local crate paths in all `Cargo.toml` file, instead of using the public crate releases. So, for example, replace this:
```
"mqtt3" = "0.1" # { path = "mqtt3" }
"netopt" = "0.1" # { path = "netopt" }
"mqttc" = "0.1" # { path = "mqttc" }
```
with this:
```
"mqtt3" = { path = "mqtt3" }
"netopt" = { path = "netopt" }
"mqttc" = { path = "mqttc" }
```